### PR TITLE
Move the options on commands to front of args. Added tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ kvstore -h
 ```
 # Version
 
-This is version 2.0 with an incompatible interface change from previous versions: the `ls <namespace>` command to list all keys and `lsval <namespace>` command to list all values are replaced by the commands `keys <namespace>` and `vals <namespace>`, respectively.
+This is version 3.0. This version has an incompatible interface change from the 2.X series: commands' options have been moved from the rear of the argument list to the front, as is custom in UNIX.
 
 # License
 

--- a/kvstore.sh
+++ b/kvstore.sh
@@ -339,7 +339,7 @@ kvstore_shellinit() {
   fi
   #echo \"ns=\$ns,pos=\$pos,comp=\${COMP_WORDS[@]}\"
   if (( pos == $cpos )); then
-    COMPREPLY=( \$( compgen -W \"ls lsinfo keys vals dump get set rm mv drop load shellinit\" -- \$cw) )
+    COMPREPLY=( \$( compgen -W \"load ls list lsinfo keys vals get set rm mv shellinit drop dump\" -- \$cw) )
   else
     local OLDIFS=\$IFS
     IFS=\$'\\n'

--- a/kvstore.sh
+++ b/kvstore.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 kvstore_usage () {
-  if [[ -n "$1" ]]; then
-    echo "$1"
-    echo
-  fi
+  echo
   echo "kvstore <command> [<namespace>] [arguments...]"
   echo "kvstore [-h|--help]"
   echo "kvstore [-v|--version]"
@@ -13,6 +10,7 @@ kvstore_usage () {
   echo
   echo "Commands:"
   echo "  ls"
+  echo "  list"
   echo "    List kv stores (namespaces)."
   echo "  lsinfo"
   echo "    List kv stores (namespaces) and other information."
@@ -20,17 +18,19 @@ kvstore_usage () {
   echo "    List keys in a namespace."
   echo "  vals <namespace>"
   echo "    List values in a namespace."
-  echo "  dump <namespace> [-v]"
-  echo "    List key/values pairs in a namespace. -v prints the"
-  echo "    namespace as a heading."
+  echo "  dump [-v] [-r] <namespace>"
+  echo "    List key/values pairs in a namespace, formatted."
+  echo "    -v (verbose) prints the namespace as a heading."
+  echo "    -r (raw) prints the raw file, no formatting."
   echo "  get <namespace> <key>"
   echo "    Get value of key."
   echo "  set <namespace> <key> <value>"
   echo "    Set value of key."
   echo "  rm <namespace> <key>"
   echo "    Remove key from store."
-  echo "  mv <namespace> <from_key> <to_key>"
-  echo "    Move (rename) key.  Fails if the destination key already exists."
+  echo "  mv [-f] <namespace> <from_key> <to_key>"
+  echo "    Move (rename) key.  Fails if the destination key already"
+  echo "     exists, unless -f (force) is specified."
   echo "  drop <namespace>"
   echo "    Delete the namespace file."
   echo "  load"
@@ -51,7 +51,17 @@ kvstore_usage () {
   echo "  # File: Shell Profile"
   echo "  \$(kvstore shellinit)"
   echo
-  echo "Version - 2.1"
+  echo "Version - 3.0"
+  ## Make sure to sync with the version printed below for the -v option
+}
+
+_kvstore_ns_check () {
+  if [[ "$1" =~ \.lock$ ]]; then
+    echo "namespace cannot end in .lock, reserved for lock protocol"
+    return 1
+  else
+    return 0
+  fi
 }
 
 _kvstore_path () {
@@ -70,10 +80,6 @@ _kvstore_lock_then () {
   local cmd="$2"
   shift
   shift
-  if [[ -z "$ns" ]]; then
-    echo "error: nothing to lock" &>2
-    return 1
-  fi
   if type flock &>/dev/null; then
     set -e
     (
@@ -138,12 +144,17 @@ _kvstore_each_file_kv () {
 }
 
 _kvstore_nonatomic_mv () {
+  local force=0
+  [[ "$1" = '-f' ]] && force=1 && shift
   local path="$1"
   local key_from="$2"
   local key_to="$3"
   local val="$4"
-  local tmp="${path}.tmp"
+  local tmp="${path}.tmp.knmv"
   _kvstore_each_file_kv "$path" _kvstore_echo_kv_if_k_nomatch "$key_from" > "$tmp"
+  if ((force)); then
+    _kvstore_nonatomic_rm "$tmp" "$key_to"
+  fi
   _kvstore_echo_kv "$key_to" "$val" >> "$tmp"
   mv -f "$tmp" "$path"
 }
@@ -152,7 +163,7 @@ _kvstore_nonatomic_set () {
   local path="$1"
   local key="$2"
   local val="$3"
-  local tmp="${path}.tmp"
+  local tmp="${path}.tmp.knset"
   _kvstore_each_file_kv "$path" _kvstore_echo_kv_if_k_nomatch "$key" > "$tmp"
   _kvstore_echo_kv "$key" "$val" >> "$tmp"
   mv -f "$tmp" "$path"
@@ -161,7 +172,7 @@ _kvstore_nonatomic_set () {
 _kvstore_nonatomic_rm () {
   local path="$1"
   local key="$2"
-  local tmp="${path}.tmp"
+  local tmp="${path}.tmp.knrm"
   _kvstore_each_file_kv "$path" _kvstore_echo_kv_if_k_nomatch "$key" > "$tmp"
   mv -f "$tmp" "$path"
 }
@@ -170,7 +181,9 @@ kvstore_ls () {
   local dir
   dir=$(_kvstore_path)
   for file in $dir/*; do
-    ! [[ "$file" =~ \.lock$ ]] && basename "$file"
+    [[ -f "$file" ]] && \
+      ! [[ "$file" =~ \.lock$ ]] && \
+      basename "$file"
   done
 }
 
@@ -244,24 +257,58 @@ kvstore_set () {
 }
 
 kvstore_mv () {
+  local force=''
+  local more_opts=1
+  local original
+  local option
+  local new
+
+  while ((more_opts)) && [[ "$1" =~ ^- ]]
+  do
+    ## Strip all leading dashes here so that -foo and --foo can both
+    ## be processed as 'foo'.
+    original="$1"
+    option="$1"
+    new=''
+    while [ ! "$new" = "$option" ] && [ ! "$option" = '--' ]
+    do
+      new=$option
+      option=${option##-}
+    done
+
+    case $option in
+      f ) force='-f'; shift;;
+      -- ) more_opts=0; shift;;
+      * )
+        echo "$original is an invalid option. See kvstore --help"; exit 1;;
+    esac
+  done
+
   local ns="$1"
   [[ -z "$ns" ]] && echo "Missing param: namespace" >&2  && return 1
   local key_from="$2"
   [[ -z "$key_from" ]] && echo "Missing param: key_from" >&2  && return 1
   local key_to="$3"
   [[ -z "$key_to" ]] && echo "Missing param: key_to" >&2 && return 1
+
   local val
   val=$(kvstore_get "$ns" "$key_from")
   if ! kvstore_get "$ns" "$key_from" >/dev/null; then
     return 2
   fi
   if kvstore_get "$ns" "$key_to" &>/dev/null; then
-    echo "Error: destination key already exists: $key_to" >&2
-    return 3
+    if ((!force)); then
+      echo "Error: destination key already exists: $key_to" >&2
+      return 3
+    fi
+  else
+    ## If the key isn't there, unset force if it was set, so we can skip the
+    ## removal from the target in the _mv below.
+    force=''
   fi
   local path
   path=$(_kvstore_path "$ns")
-  _kvstore_lock_then "${path}.lock" _kvstore_nonatomic_mv "$path" "$key_from" "$key_to" "$val"
+  _kvstore_lock_then "${path}.lock" _kvstore_nonatomic_mv $force "$path" "$key_from" "$key_to" "$val"
 }
 
 
@@ -292,7 +339,7 @@ kvstore_shellinit() {
   fi
   #echo \"ns=\$ns,pos=\$pos,comp=\${COMP_WORDS[@]}\"
   if (( pos == $cpos )); then
-    COMPREPLY=( \$( compgen -W \"ls get set rm mv shellinit\" -- \$cw) )
+    COMPREPLY=( \$( compgen -W \"ls lsinfo keys vals dump get set rm mv drop load shellinit\" -- \$cw) )
   else
     local OLDIFS=\$IFS
     IFS=\$'\\n'
@@ -334,11 +381,41 @@ kvstore_drop () {
 }
 
 kvstore_dump () {
+  local verbose=0
+  local raw=0
+  local more_opts=1
+  local original
+  local option
+  local new
+
+  while ((more_opts)) && [[ "$1" =~ ^- ]]
+  do
+    ## Strip all leading dashes here so that -foo and --foo can both
+    ## be processed as 'foo'.
+    original="$1"
+    option="$1"
+    new=''
+    while [ ! "$new" = "$option" ] && [ ! "$option" = '--' ]
+    do
+      new=$option
+      option=${option##-}
+    done
+
+    case $option in
+      v ) verbose=1; shift;;
+      r ) raw=1; shift;;
+      -- ) more_opts=0; shift;;
+      * )
+        echo "$original is an invalid option. See kvstore --help"; exit 1;;
+    esac
+  done
+
   local ns="$1"
   [[ -z "$ns" ]] && echo "Missing param: namespace" >&2 && return 1
-  [[ "$2" = '-v' ]] && echo $(basename $ns):
+  ((verbose)) && echo "$(basename $ns):"
   path=$(_kvstore_path "$ns")
-  cat ${path}
+  ((raw)) && cat ${path} || \
+  cat ${path} | sed -e 's/^/"/' -e's/\t/"=>"/' -e 's/$/"/'
   return $?
 }
 
@@ -349,66 +426,76 @@ kvstore () {
     echo "kvstore -h to see usage" >&2
     return 1
   fi
+  shift
 
-  ## $2 is namespace, $3 is key, $4 is value
-  if [[ "$2" =~ \.lock$ ]]; then
-    echo "namespace cannot end in .lock, reserved for lock protocol"
-    return 1
-  fi
   case "$cmd" in
     -h|--help)
-      kvstore_usage "$@"
+      kvstore_usage
       return 0
       ;;
     -v|--version)
-      echo 2.0
+      echo 3.0
+      ## Make sure to keep in sync with the version in the usage statement above.
       return 0
       ;;
-    ls)
-      kvstore_ls "$2"
+    load)
+      if [[ "$(basename -- $0)" =~ kvstore ]]
+      then
+        echo "Warning: it looks like you are just running"
+        echo "         the $0 script and not sourcing it"
+        echo "         into the environment. The correct"
+        echo "         usage for the load command is"
+        echo
+        echo "         . $0 load"
+        echo
+        return 1
+      else
+        return 0             ## Do nothing if sourcing into environment.
+      fi
+      ;;
+    ls | list)
+      kvstore_ls "$@"        ## namespace
       return $?
       ;;
     lsinfo)
-      kvstore_lsinfo "$2"
+      kvstore_lsinfo "$@"    ## namespace
       return $?
       ;;
     keys)
-      kvstore_keys "$2"
+      kvstore_keys "$@"      ## namespace
       return $?
       ;;
     vals)
-      kvstore_vals "$2"
+      kvstore_vals "$@"      ## namespace
       return $?
       ;;
     get)
-      kvstore_get "$2" "$3"
+      kvstore_get "$@"       ## namespace key
       return $?
       ;;
     set)
-      kvstore_set "$2" "$3" "$4"
+      kvstore_set "$@"       ## namespace key value
       return $?
       ;;
     rm)
-      kvstore_rm "$2" "$3"
+      kvstore_rm "$@"        ## namespace key
       return $?
       ;;
     mv)
-      kvstore_mv "$2" "$3" "$4"
+      kvstore_mv "$@"        ## [-f] namespace from_key to_key
       return $?
       ;;
     shellinit)
-      kvstore_shellinit "$2"
+      kvstore_shellinit "$@" ## namespace
       return 0
       ;;
     drop)
-      kvstore_drop "$2"
+      kvstore_drop "$@"      ## namespace
       return $?
       ;;
     dump)
-      kvstore_dump "$2"
+      kvstore_dump "$@"      ## [-v] [-r] namespace
       return $?
-    load)
-      return 0 ## Do nothing if loading.
       ;;
     *)
       echo "Error: Unrecognized command: $cmd" >&2

--- a/testing.sh
+++ b/testing.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# testing.sh - a test script to prevent regressions
+
+settest () {
+  ((tnum+=1))
+  tname=$(printf '%03d' $tnum)
+  printf 'test %3d\n' $tnum
+}
+
+dotest () {
+  settest
+  "$@" 1>tout.$tname 2>terr.$tname
+}
+
+scriptcmd=$(pwd)/kvstore.sh
+funccmd=kvstore
+
+TEST_ROOT=$(mktemp -d)
+
+mkdir $TEST_ROOT/store
+export KVSTORE_DIR=$TEST_ROOT/store
+
+mkdir $TEST_ROOT/test
+export TEST_DIR=$TEST_ROOT/test
+
+builtin cd $TEST_DIR
+
+echo stores in $KVSTORE_DIR
+echo test results in $TEST_DIR
+
+tnum=0
+tname=''
+for testtype in script functions
+do
+  if [ "$testtype" = 'script' ]
+  then
+    CMD=$scriptcmd
+  else
+    dotest $CMD load
+    dotest . $CMD load
+    CMD=$funccmd
+  fi
+
+  settest
+  declare -F | grep kvstore 1>tout.$tname 2>terr.$tname
+  dotest $CMD ls
+
+  dotest $CMD set teststore1_$testtype key1 val1
+  dotest $CMD get teststore1_$testtype key1
+  dotest $CMD set teststore1_$testtype key2 val2
+  dotest $CMD set teststore1_$testtype 'key3 with spaces' 'val3 with spaces'
+  dotest $CMD get teststore1_$testtype 'key3 with spaces'
+
+  dotest $CMD set teststore2_$testtype key12 val12
+  dotest $CMD get teststore2_$testtype key12
+  dotest $CMD set teststore2_$testtype key22 val22
+  dotest $CMD set teststore2_$testtype 'key32 with spaces' 'val32 with spaces'
+  dotest $CMD get teststore2_$testtype 'key32 with spaces'
+
+  dotest $CMD ls
+  dotest $CMD lsinfo
+
+  for i in 1 2
+  do
+    dotest $CMD keys teststore${i}_$testtype
+    dotest $CMD vals teststore${i}_$testtype
+    dotest $CMD dump teststore${i}_$testtype
+    dotest $CMD dump -v teststore${i}_$testtype
+    dotest $CMD dump -r teststore${i}_$testtype
+    dotest $CMD dump -v -r teststore${i}_$testtype
+  done
+
+  dotest $CMD rm teststore1_$testtype key1
+  dotest $CMD dump -r teststore1_$testtype
+
+  dotest $CMD mv teststore2_$testtype key12 key122
+  dotest $CMD dump -r teststore2_$testtype
+
+  dotest $CMD mv teststore2_$testtype key122 key22
+  dotest $CMD dump -r teststore2_$testtype
+
+  dotest $CMD mv -f teststore2_$testtype key122 key22
+  dotest $CMD dump -r teststore2_$testtype
+
+  dotest $CMD rm teststore2_$testtype key22
+  dotest $CMD dump -r teststore2_$testtype
+
+  dotest $CMD drop teststore1_$testtype
+  dotest $CMD ls
+
+  dotest $CMD drop teststore1_$testtype
+  dotest $CMD ls
+done
+
+for i in $(seq 1 $tnum)
+do
+  id=$(printf '%03d' $i)
+  for j in tout terr
+  do
+    file=$j.$id
+    [ -s $file ] && echo "=== $file ===" && cat $file && echo
+  done
+done > testresults
+
+master=$(dirname $scriptcmd)/testresults
+echo "Comparing this test run's results against $master..."
+diff testresults $master

--- a/testresults
+++ b/testresults
@@ -1,0 +1,290 @@
+=== tout.004 ===
+val1
+
+=== tout.007 ===
+val3 with spaces
+
+=== tout.009 ===
+val12
+
+=== tout.012 ===
+val32 with spaces
+
+=== tout.013 ===
+teststore1_script
+teststore2_script
+
+=== tout.014 ===
+teststore1_script
+    entries:    3 bytes:    54 Last updated:2017-10-21 00:51:34.129136000 -0400
+teststore2_script
+    entries:    3 bytes:    60 Last updated:2017-10-21 00:51:35.440416600 -0400
+
+=== tout.015 ===
+key1
+key2
+key3 with spaces
+
+=== tout.016 ===
+val1
+val2
+val3 with spaces
+
+=== tout.017 ===
+"key1"=>"val1"
+"key2"=>"val2"
+"key3 with spaces"=>"val3 with spaces"
+
+=== tout.018 ===
+teststore1_script:
+"key1"=>"val1"
+"key2"=>"val2"
+"key3 with spaces"=>"val3 with spaces"
+
+=== tout.019 ===
+key1	val1
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.020 ===
+teststore1_script:
+key1	val1
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.021 ===
+key12
+key22
+key32 with spaces
+
+=== tout.022 ===
+val12
+val22
+val32 with spaces
+
+=== tout.023 ===
+"key12"=>"val12"
+"key22"=>"val22"
+"key32 with spaces"=>"val32 with spaces"
+
+=== tout.024 ===
+teststore2_script:
+"key12"=>"val12"
+"key22"=>"val22"
+"key32 with spaces"=>"val32 with spaces"
+
+=== tout.025 ===
+key12	val12
+key22	val22
+key32 with spaces	val32 with spaces
+
+=== tout.026 ===
+teststore2_script:
+key12	val12
+key22	val22
+key32 with spaces	val32 with spaces
+
+=== tout.028 ===
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.030 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== terr.031 ===
+Error: destination key already exists: key22
+
+=== tout.032 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== terr.033 ===
+Error: destination key already exists: key22
+
+=== tout.034 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== tout.036 ===
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== tout.038 ===
+teststore2_script
+
+=== terr.039 ===
+rm: cannot remove '/tmp/tmp.kCzstXmPvD/store/teststore1_script': No such file or directory
+
+=== tout.040 ===
+teststore2_script
+
+=== tout.041 ===
+Warning: it looks like you are just running
+         the /home/Matthew/gits/github/matthewpersico/kvstore/wt/v4.0/kvstore.sh script and not sourcing it
+         into the environment. The correct
+         usage for the load command is
+
+         . /home/Matthew/gits/github/matthewpersico/kvstore/wt/v4.0/kvstore.sh load
+
+
+=== tout.043 ===
+declare -f _kvstore_each_file_kv
+declare -f _kvstore_echo_kv
+declare -f _kvstore_echo_kv_if_k_nomatch
+declare -f _kvstore_echo_v_if_k_match
+declare -f _kvstore_get_either
+declare -f _kvstore_lock_then
+declare -f _kvstore_nonatomic_mv
+declare -f _kvstore_nonatomic_rm
+declare -f _kvstore_nonatomic_set
+declare -f _kvstore_ns_check
+declare -f _kvstore_path
+declare -f kvstore
+declare -f kvstore_drop
+declare -f kvstore_dump
+declare -f kvstore_get
+declare -f kvstore_keys
+declare -f kvstore_ls
+declare -f kvstore_lsinfo
+declare -f kvstore_mv
+declare -f kvstore_rm
+declare -f kvstore_set
+declare -f kvstore_shellinit
+declare -f kvstore_usage
+declare -f kvstore_vals
+
+=== tout.044 ===
+teststore2_script
+
+=== tout.046 ===
+val1
+
+=== tout.049 ===
+val3 with spaces
+
+=== tout.051 ===
+val12
+
+=== tout.054 ===
+val32 with spaces
+
+=== tout.055 ===
+teststore1_functions
+teststore2_functions
+teststore2_script
+
+=== tout.056 ===
+teststore1_functions
+    entries:    3 bytes:    54 Last updated:2017-10-21 00:51:43.708828800 -0400
+teststore2_functions
+    entries:    3 bytes:    60 Last updated:2017-10-21 00:51:44.709349800 -0400
+teststore2_script
+    entries:    2 bytes:    49 Last updated:2017-10-21 00:51:42.153712600 -0400
+
+=== tout.057 ===
+key1
+key2
+key3 with spaces
+
+=== tout.058 ===
+val1
+val2
+val3 with spaces
+
+=== tout.059 ===
+"key1"=>"val1"
+"key2"=>"val2"
+"key3 with spaces"=>"val3 with spaces"
+
+=== tout.060 ===
+teststore1_functions:
+"key1"=>"val1"
+"key2"=>"val2"
+"key3 with spaces"=>"val3 with spaces"
+
+=== tout.061 ===
+key1	val1
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.062 ===
+teststore1_functions:
+key1	val1
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.063 ===
+key12
+key22
+key32 with spaces
+
+=== tout.064 ===
+val12
+val22
+val32 with spaces
+
+=== tout.065 ===
+"key12"=>"val12"
+"key22"=>"val22"
+"key32 with spaces"=>"val32 with spaces"
+
+=== tout.066 ===
+teststore2_functions:
+"key12"=>"val12"
+"key22"=>"val22"
+"key32 with spaces"=>"val32 with spaces"
+
+=== tout.067 ===
+key12	val12
+key22	val22
+key32 with spaces	val32 with spaces
+
+=== tout.068 ===
+teststore2_functions:
+key12	val12
+key22	val22
+key32 with spaces	val32 with spaces
+
+=== tout.070 ===
+key2	val2
+key3 with spaces	val3 with spaces
+
+=== tout.072 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== terr.073 ===
+Error: destination key already exists: key22
+
+=== tout.074 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== terr.075 ===
+Error: destination key already exists: key22
+
+=== tout.076 ===
+key22	val22
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== tout.078 ===
+key32 with spaces	val32 with spaces
+key122	val12
+
+=== tout.080 ===
+teststore2_functions
+teststore2_script
+
+=== terr.081 ===
+rm: cannot remove '/tmp/tmp.kCzstXmPvD/store/teststore1_functions': No such file or directory
+
+=== tout.082 ===
+teststore2_functions
+teststore2_script


### PR DESCRIPTION
README.md
o Version update, api change note.

kvstore.sh
o All commands that take options now have their options moved to the
  front of their command arg list.

_kvstore_lock_then():
  o Remove useless lock check.

_kvstore_nonatomic_mv():
  o Option processing for --force added, tmp file renamed for clarity.

_kvstore_nonatomic_rm():
  o tmp file renamed for clarity.

_kvstore_nonatomic_set():
  o tmp file renamed for clarity.

_kvstore_ns_check():
  o Added to replace inline check.

kvstore():
  o list as alias for ls

kvstore_dump():
  o --verbose added to print kv store name before data, --raw for a quick
    dump, default is to print something prettier, with arrows.

kvstore_mv():
  o Added processing for forcing an overwrite of existing key.

kvstore_shellinit():
  o Added new commands to completion list.

kvstore_usage():
  o Do not need to echo the command we are usaging.

testing.sh
o Run some tests to prevent regressions.

testresults
o The results of running testing.sh to compare against future updates.